### PR TITLE
Support kerberos setting

### DIFF
--- a/embulk-input-parquet_hadoop/src/main/java/org/embulk/input/parquet_hadoop/ConfigurationFactory.java
+++ b/embulk-input-parquet_hadoop/src/main/java/org/embulk/input/parquet_hadoop/ConfigurationFactory.java
@@ -26,6 +26,7 @@
 package org.embulk.input.parquet_hadoop;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigException;
@@ -73,6 +74,7 @@ public class ConfigurationFactory
             logger.trace("embulk-input-parquet_hadoop: load a config: {}:{}", entry.getKey(), entry.getValue());
             c.set(entry.getKey(), entry.getValue());
         }
+        UserGroupInformation.setConfiguration(c);
 
         // For logging
         for (Map.Entry<String, String> entry : c) {


### PR DESCRIPTION
Add `UserGroupInformation.setConfiguration` for kerberos authentication.

Hi, I tried this plugin with hdfs in kerberos environment.

test.yml
```
in:
  type: parquet_hadoop
  config_files:
    - /my-hadoop-conf/core-site.xml
    - /my-hadoop-conf/hdfs-site.xml
  config:
    parquet.read.bad.record.threshold: 0.01
    hadoop.security.authentication: 'kerberos' # add
  path: /user/hadoop/test_dir/*.snappy.parquet
  parquet_log_level: WARNING
```
$ embulk preview  test.yaml

error message
```
java.lang.RuntimeException: org.apache.hadoop.security.AccessControlException: SIMPLE authentication is not enabled.  Available:[TOKEN, KERBEROS]
```

I added `UserGroupInformation.setConfiguration` reference to this PR. https://github.com/civitaspo/embulk-output-hdfs/pull/24

I remade the gem and tried it, and it succeeded.

$ embulk preview test.yml
```
record (json) : {"hoge":"foo"}
```